### PR TITLE
converted string to utf-8 encoding for stdin.write()

### DIFF
--- a/submit-pbs-loop.py
+++ b/submit-pbs-loop.py
@@ -30,7 +30,10 @@ for i in range(1, 10):
     %s""" % (job_name, walltime, processors, job_name, job_name, command)
     
     # Send job_string to qsub
-    proc.stdin.write(job_string.encode('utf-8'))
+    if (sys.version_info > (3, 0)):
+        proc.stdin.write(job_string.encode('utf-8'))
+    else:
+        proc.stdin.write(job_string)
     out, err = proc.communicate()
     
     # Print your job and the system response to the screen as it's submitted

--- a/submit-pbs-loop.py
+++ b/submit-pbs-loop.py
@@ -34,7 +34,7 @@ for i in range(1, 10):
     out, err = proc.communicate()
     
     # Print your job and the system response to the screen as it's submitted
-    print job_string
-    print out
+    print(job_string)
+    print(out)
     
     time.sleep(0.1)

--- a/submit-pbs-loop.py
+++ b/submit-pbs-loop.py
@@ -30,7 +30,7 @@ for i in range(1, 10):
     %s""" % (job_name, walltime, processors, job_name, job_name, command)
     
     # Send job_string to qsub
-    proc.stdin.write(job_string)
+    proc.stdin.write(job_string.encode('utf-8'))
     out, err = proc.communicate()
     
     # Print your job and the system response to the screen as it's submitted


### PR DESCRIPTION
This code doesn't work for python 3.5 and above as proc.stdin.write(...) function expects bytes in arguments instead of strings.